### PR TITLE
Update maven-shade-plugin

### DIFF
--- a/shade/project.clj
+++ b/shade/project.clj
@@ -4,4 +4,4 @@
   :scm {:dir ".."}
   :license {:name "Eclipse Public License" :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.apache.maven.plugins/maven-shade-plugin "3.0.0"]])
+                 [org.apache.maven.plugins/maven-shade-plugin "3.2.4"]])


### PR DESCRIPTION
I was getting errors like the one below when running `lein shade-jar`, and found that they went away when I updated `maven-shade-plugin`.
```
java.lang.IllegalArgumentException: null
 at org.objectweb.asm.ClassReader.<init> (:-1)
    org.objectweb.asm.ClassReader.<init> (:-1)
    org.objectweb.asm.ClassReader.<init> (:-1)
    org.apache.maven.plugins.shade.DefaultShader.addRemappedClass (DefaultShader.java:418)
    org.apache.maven.plugins.shade.DefaultShader.shadeSingleJar (DefaultShader.java:220)
    org.apache.maven.plugins.shade.DefaultShader.shadeJars (DefaultShader.java:181)
    org.apache.maven.plugins.shade.DefaultShader.shade (DefaultShader.java:104)
    sun.reflect.NativeMethodAccessorImpl.invoke0 (NativeMethodAccessorImpl.java:-2)
    sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    java.lang.reflect.Method.invoke (Method.java:498)
    clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:167)
    clojure.lang.Reflector.invokeInstanceMethod (Reflector.java:102)
    shade.core$shade.invokeStatic (core.clj:60)
    shade.core$shade.invoke (core.clj:55)
    leiningen.shade_jar$shade_jar.invokeStatic (shade_jar.clj:37)
    leiningen.shade_jar$shade_jar.invoke (shade_jar.clj:24)
    clojure.lang.AFn.applyToHelper (AFn.java:154)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.core$apply.invokeStatic (core.clj:667)
    clojure.core$apply.invoke (core.clj:660)
    leiningen.core.main$partial_task$fn__7330.doInvoke (main.clj:284)
    clojure.lang.RestFn.invoke (RestFn.java:410)
    clojure.lang.AFn.applyToHelper (AFn.java:154)
    clojure.lang.RestFn.applyTo (RestFn.java:132)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:31)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:667)
```